### PR TITLE
Set SLACK_ALERTS_URL to empty string

### DIFF
--- a/americanhandelsociety/test_settings.py
+++ b/americanhandelsociety/test_settings.py
@@ -34,3 +34,6 @@ MIDDLEWARE = [
 STATIC_URL = "/static/"
 STATIC_ROOT = None
 STATICFILES_STORAGE = None
+
+# Slack integration
+SLACK_ALERTS_URL = ""


### PR DESCRIPTION
This PR sets SLACK_ALERTS_URL to an empty string, so the app does not send notifications to Slack when running tests locally.