### PR TITLE
Expose is_superuser in django dashboard

### DIFF
--- a/americanhandelsociety_app/admin.py
+++ b/americanhandelsociety_app/admin.py
@@ -32,7 +32,7 @@ class Admin(UserAdmin):
                 )
             },
         ),
-        ("Authorization", {"fields": ("is_staff", "is_active")}),
+        ("Authorization", {"fields": ("is_staff", "is_active", "is_superuser")}),
     )
     add_fieldsets = (
         (


### PR DESCRIPTION
This PR exposes the `is_superuser` field in the Django dashboard, so it is possible to add and remove superusers via the dashboard.