### PR TITLE
Add entry for 2021 Serwer lecture

### DIFF
--- a/americanhandelsociety_app/constants.py
+++ b/americanhandelsociety_app/constants.py
@@ -162,6 +162,12 @@ HONORARY_DIRECTORS = [
 
 HOWARD_SERWER_LECTURES = [
     {
+        "year": 2021,
+        "speaker": "Berta Joncus",
+        "title": "Posterity vs Celebrity: Handel Studies and the 21st Century",
+        "location": "Virtual Conference – Hosted by Indiana University",
+    },
+    {
         "year": 2019,
         "speaker": "Ellen Rosand",
         "title": "Handel's 'Music'",


### PR DESCRIPTION
# Description

Closes #97.

This PR adds an entry for the 2021 Serwer lecture. The table on the events page should look like this: 

<img width="1512" alt="Screen Shot 2022-02-06 at 8 36 40 PM" src="https://user-images.githubusercontent.com/13078679/152716136-b14ecad4-4c42-4b98-8137-694d201d13b6.png">

