### PR TITLE
Return full address in admin view

### DIFF
--- a/americanhandelsociety_app/admin.py
+++ b/americanhandelsociety_app/admin.py
@@ -6,7 +6,7 @@ from .models import Member, Address
 
 class Admin(UserAdmin):
     model = Member
-    list_display = ("first_name", "last_name", "email", "id")
+    list_display = ("first_name", "last_name", "email", "id", "address")
     list_filter = (
         "email",
         "available_in_directory",

--- a/americanhandelsociety_app/models.py
+++ b/americanhandelsociety_app/models.py
@@ -3,6 +3,7 @@ import uuid
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.contrib.auth.base_user import BaseUserManager
+from django.forms.models import model_to_dict
 
 
 class MemberManager(BaseUserManager):
@@ -102,4 +103,8 @@ class Address(models.Model):
     country = models.CharField(max_length=50, blank=True)
 
     def __str__(self):
-        return self.street_address
+        full_address_values = [
+            val for val in model_to_dict(self, exclude=["id"]).values() if val
+        ]
+
+        return f"{', '.join(full_address_values)}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,10 +145,22 @@ def django_db_setup(
 
 
 @pytest.fixture
-def member():
-    address_data = {"street_address": "25 Brook Street", "city": "London"}
+def address():
+    address_data = {
+        "street_address": "The Handel House Trust Ltd",
+        "street_address_2": "25 Brook Street",
+        "city": "London",
+        "zip_postal_code": "W1K 4HB",
+        "country": "UK",
+    }
+
     address = Address.objects.create(**address_data)
 
+    return address
+
+
+@pytest.fixture
+def member(address):
     data = {
         "email": "rodelinda@lombardy.sa",
         "password": "cuzzoni",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -130,3 +130,11 @@ def test_address_model_is_valid_with_street_address_only():
 
     assert address.street_address == street_address
     assert str(address) == street_address
+
+
+@pytest.mark.django_db
+def test_address_model_str_representation(address):
+    assert (
+        str(address)
+        == "The Handel House Trust Ltd, 25 Brook Street, London, W1K 4HB, UK"
+    )


### PR DESCRIPTION
# Description
This PR does two things:
* it includes all available address data in the `Address` string representation 
* it exposes the "address" field in the Users table in the admin dashboard

`/admin` should look like this: 

<img width="1533" alt="Screen Shot 2022-03-01 at 3 11 21 PM" src="https://user-images.githubusercontent.com/13078679/156249903-3900a47c-446d-45d2-9b24-d6fe527dab4e.png">


Closes #102 

