### PR TITLE
Upgrade to django 3.2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 psycopg2-binary = "*"
 django-paypal = "*"
-fontawesome-free = "*"
+fontawesomefree = "*"
 django = "==3.2"
 python-dateutil = "*"
 whitenoise = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d1445193f245b1d58b4e733348caed7e5ae185a037ca8ea623f5451542a18333"
+            "sha256": "b8a775efc40284ab10355bcf71a5cb066df05624751270bcf10e8d8ad1ee103f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -37,7 +37,7 @@
                 "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                 "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.12"
         },
         "dj-database-url": {
@@ -78,12 +78,12 @@
             "index": "pypi",
             "version": "==0.5.17"
         },
-        "fontawesome-free": {
+        "fontawesomefree": {
             "hashes": [
-                "sha256:5d3d0edbf6ce0f7cd56978a31ea4ea697a8bb28103b5c528b3aa1f0a4474d9a1"
+                "sha256:b077739369c013e8c8cf5edd59cb7fca3a5b16803d632cd466a62fd2e28937cb"
             ],
             "index": "pypi",
-            "version": "==5.15.4"
+            "version": "==6.1.1"
         },
         "gunicorn": {
             "hashes": [
@@ -98,7 +98,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.3"
         },
         "pillow": {
@@ -251,7 +251,7 @@
                 "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae",
                 "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==0.4.2"
         },
         "urllib3": {
@@ -330,7 +330,7 @@
                 "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                 "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.12"
         },
         "click": {
@@ -377,7 +377,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.3"
         },
         "iniconfig": {

--- a/americanhandelsociety/settings.py
+++ b/americanhandelsociety/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "fontawesome-free",
+    "fontawesomefree",
     "paypal.standard.ipn",
     "captcha",
 ]

--- a/americanhandelsociety_app/templates/base.html
+++ b/americanhandelsociety_app/templates/base.html
@@ -22,10 +22,9 @@
     <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
     <link href="{% static 'css/custom.css' %}" rel="stylesheet">
 
-    <!-- Our project just needs Font Awesome Free's Solid + Brand files -->
-    <link href="{% static 'fontawesome_free/css/fontawesome.css' %}" rel="stylesheet" type="text/css">
-    <link href="{% static 'fontawesome_free/css/solid.css' %}" rel="stylesheet" type="text/css">
-
+    <!-- The AHS project just needs Font Awesome Free's Solid + Brand files -->
+    <link href="{% static 'fontawesomefree/css/fontawesome.css' %}" rel="stylesheet" type="text/css">
+    <link href="{% static 'fontawesomefree/css/solid.css' %}" rel="stylesheet" type="text/css">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
This PR upgrades the website to Django 3.2. 

### Notes:

* this incremental upgrade takes us from Django 3.1.9 to 3.2. The release notes do not include any deprecated features in use in the AHS project: https://docs.djangoproject.com/en/4.0/releases/3.2/#features-deprecated-in-3-2 (N.b., we use EmailValidator, but not the deprecated arg and attribute.
* the only notable change made in service of Django 3.2: upgrading Fontawesome. "fontawesome-free" is not compatbible with Django 3.2+:
    * https://github.com/FortAwesome/Font-Awesome/issues/17801
    * https://fontawesome.com/docs/web/use-with/python-django

### Manual QA:
I clicked through the entire site (including logging in and out, profile updates, etc.) I plan to deploy this to staging (after merging) and doing the same.

The pytest suite passed, too.
