### PR TITLE
[Issue-117] fix flaky test

### DIFF
--- a/tests/integration/test_filter.py
+++ b/tests/integration/test_filter.py
@@ -53,7 +53,7 @@ def test_filter_matches_admin_updated_past_month(
     artificially_backdated_pre_004_migration_members, member, address
 ):
     qs = Member.objects.all()
-    random_member = choice(qs)
+    random_member = choice(artificially_backdated_pre_004_migration_members)
     random_member.address = address
     random_member.save()
     admin = Admin(Member, AdminSite)


### PR DESCRIPTION
The reason it was flaky is because I use two fixtures: one with artificially
ackdated members, and one with the generic member fixture, who is not artificially
backdated. The artificially backdated members do NOT evalutate to updated_past_month=True,
but the other member does. Previously, I was choosing a random member to update from the entire
queryset in the hopes of forcing that member to be presented in the set of updated_past_month=True.
On occasions where the member who already evaluted to updated_past_month=True is chosen, then no
data changes in the populated of the queryset occurred, resulting in the failure.