### PR TITLE
Order members table and extend page length

### DIFF
--- a/americanhandelsociety_app/templates/people.html
+++ b/americanhandelsociety_app/templates/people.html
@@ -98,7 +98,7 @@
 				"retrieve": true, // https://datatables.net/manual/tech-notes/3
 				"lengthChange": false,
 				"ordering": false,
-				"pageLength": 10,
+				"pageLength": 20,
             	"pagingType": "simple",
 				"language": {
 					"search": "",

--- a/americanhandelsociety_app/views.py
+++ b/americanhandelsociety_app/views.py
@@ -193,7 +193,9 @@ class Newsletter(View):
 
 class People(ListView):
     context_object_name = "ahs_members"
-    queryset = Member.objects.exclude(available_in_directory=False)
+    queryset = Member.objects.exclude(available_in_directory=False).order_by(
+        "last_name"
+    )
 
     def get_template_names(self):
         return ["people.html"]


### PR DESCRIPTION
This PR updates the members directory table:
* orders the members by last name
* increase page length of the members table

http://127.0.0.1:8000/people/

<img width="1643" alt="Screen Shot 2022-09-12 at 9 51 50 PM" src="https://user-images.githubusercontent.com/13078679/189796981-30723058-ff61-4e59-95b9-d03749dae45c.png">

These adjustments come from a request from an AHS board member.