### PR TITLE
Add dealine extension alert

### DIFF
--- a/americanhandelsociety_app/static/css/custom.css
+++ b/americanhandelsociety_app/static/css/custom.css
@@ -100,6 +100,13 @@ a.disabled {
   padding: 1rem;
 }
 
+.alert-info {
+  background-color: #fed76694;
+  border: 2px solid #fed766;
+  padding: 1rem;
+  color: #7f5f01;
+}
+
 .font-enhance {
 	font-family: var(--font-headers);
 }

--- a/americanhandelsociety_app/static/css/events.css
+++ b/americanhandelsociety_app/static/css/events.css
@@ -51,6 +51,10 @@ div.padding-md {
     margin: 90px 0;
 }
 
+div.alert-info {
+    margin: 30px 0px;
+}
+
 /* Small screens */
 @media screen and (min-width: 0px) and (max-width: 768px) {
 

--- a/americanhandelsociety_app/templates/events.html
+++ b/americanhandelsociety_app/templates/events.html
@@ -24,9 +24,10 @@
 <div class="outer-container">
     <div class="card">
         <p class="font-enhance"><strong>Call for Papers: American Handel Society Conference 2023</strong></p>
+        <div class="alert-info"><p><span class="font-enhance">Deadline extension:</span> The American Handel Society is extending the deadline of its call for papers to October 24, 2022.  It also wishes to announce that the organizers of the conference are working to offer remote delivery of papers in special cases, so those who cannot attend in person may still consider submitting a proposal. </p></div>
         <p>The biennial conference of the American Handel Society will be held in Bloomington, Indiana, hosted by the Jacobs School of Music at Indiana University Bloomington, on February 23–26, 2023. Commencing on Handel's 338th birthday, the conference will include academic panels, the Howard Serwer Memorial Lecture, and performances by IU's Historical Performance Institute.</p>
         <p>The Society invites submission of abstracts for papers on any topic connected with Handel's life, his music, his close contemporaries, or the contexts in which his music was composed and/or performed. Given the setting, the Program Committee would especially appreciate topics on issues of performance and performance practice.</p>
-        <p>Abstracts of no more than 500 words may be sent by October 3, 2022 to the program chair, Roger Freitas, at <a href="mailto:rfreitas@esm.rochester.edu">rfreitas@esm.rochester.edu</a>.</p>
+        <p>Abstracts of no more than 500 words may be sent by October 24, 2022 to the program chair, Roger Freitas, at <a href="mailto:rfreitas@esm.rochester.edu">rfreitas@esm.rochester.edu</a>.</p>
     </div>
 </div>
 


### PR DESCRIPTION
This PR adds an `alert-info` to announce an extension of the CFP for the 2023 conference.