### PR TITLE
Fix link for hamburg

### DIFF
--- a/americanhandelsociety_app/constants.py
+++ b/americanhandelsociety_app/constants.py
@@ -2,7 +2,7 @@ RESEARCH_MATERIALS = {
     "open_source": [
         {
             "title": "Bibliothekssystem Universität Hamburg",
-            "url": "https://digitalisate.sub.uni-hamburg.de/musikalien.html",
+            "url": "https://digitalisate.sub.uni-hamburg.de/",
             "description": "Includes some digitized Handel conducting scores.",
         },
         {


### PR DESCRIPTION
This PR replaces an invalid URL with a valid one (for Bibliothekssystem Universität Hamburg).