### PR TITLE
Update events with Halle CFP

### DIFF
--- a/americanhandelsociety_app/templates/events.html
+++ b/americanhandelsociety_app/templates/events.html
@@ -30,26 +30,26 @@
 </div>
 
 <div class="outer-container padding-md">
-        <h2>Recently Past Festivals</h2>
-        <div class="inner-container-col padding-sm">
-            <p class="font-sm margin-sm"><strong>February 24-26, 2023</strong></p>
-            <p class="margin-sm">Jacobs School of Music at Indiana University Bloomington</p>
-            <p class="font-sm"><a href="https://jacobsacademy.indiana.edu/descriptions/american-handel-society-conference.html" target="_blank"><i class="fas fa-external-link-square-alt"></i> Visit website</a></p>
-        </div>
-        <div class="inner-container-col padding-sm">
-            <p class="font-sm margin-sm"><strong>March 11–14, 2021</strong></p>
-            <p class="margin-sm">Virtual Conference</br>Hosted by Indiana University</p>
-            <p class="font-sm"><a href="https://iu.pressbooks.pub/ahsconference2021/front-matter/introduction/" target="_blank"><i class="fas fa-external-link-square-alt"></i> Visit website</a></p>
-        </div>
-        <div class="inner-container-col padding-sm">
-            <p class="font-sm margin-sm"><strong>April 6-9, 2017</strong></p>
-            <p class="margin-sm">Princeton University</p>
-        </div>
-        <div class="inner-container-col">
-            <p class="font-sm margin-sm"><strong>April 23-26, 2015</strong></p>
-            <p class="margin-sm">Iowa City</p>
-            <p class="font-sm"><a href="https://music.uiowa.edu/resources/news/joint-meeting-american-handel-society-society-seventeenth-century-music" target="_blank"><i class="fas fa-external-link-square-alt"></i> Visit website</a></p>
-        </div>
+    <h2>Recently Past Festivals</h2>
+    <div class="inner-container-col padding-sm">
+        <p class="font-sm margin-sm"><strong>February 24-26, 2023</strong></p>
+        <p class="margin-sm">Jacobs School of Music at Indiana University Bloomington</p>
+        <p class="font-sm"><a href="https://jacobsacademy.indiana.edu/descriptions/american-handel-society-conference.html" target="_blank"><i class="fas fa-external-link-square-alt"></i> Visit website</a></p>
+    </div>
+    <div class="inner-container-col padding-sm">
+        <p class="font-sm margin-sm"><strong>March 11–14, 2021</strong></p>
+        <p class="margin-sm">Virtual Conference</br>Hosted by Indiana University</p>
+        <p class="font-sm"><a href="https://iu.pressbooks.pub/ahsconference2021/front-matter/introduction/" target="_blank"><i class="fas fa-external-link-square-alt"></i> Visit website</a></p>
+    </div>
+    <div class="inner-container-col padding-sm">
+        <p class="font-sm margin-sm"><strong>April 6-9, 2017</strong></p>
+        <p class="margin-sm">Princeton University</p>
+    </div>
+    <div class="inner-container-col">
+        <p class="font-sm margin-sm"><strong>April 23-26, 2015</strong></p>
+        <p class="margin-sm">Iowa City</p>
+        <p class="font-sm"><a href="https://music.uiowa.edu/resources/news/joint-meeting-american-handel-society-society-seventeenth-century-music" target="_blank"><i class="fas fa-external-link-square-alt"></i> Visit website</a></p>
+    </div>
 </div>
 
 <div class="outer-container padding-md">
@@ -80,11 +80,6 @@
     <h2>Encounters with Eighteenth-Century Music: A Virtual Forum</h2>
     <div class="inner-container-col padding-top-xs">
         <p class="padding-sm">The American Bach Society, American Handel Society, Haydn Society of North America, Mozart Society of America, and Society for Eighteenth-Century Music sponsor a series of virtual presentations and conversations.</p>
-        <p class="padding-sm">Friday, September 8, 2023, 3:30–5:00 pm EDT<br>"Celebrating Elaine Sisman: Haydn and the Classical Variation and Mozart: The 'Jupiter' Symphony at 30"</p>
-        <p class="padding-sm">Thursday, October 26, 2023, 3:00–4:30 pm EDT<br>"Listening in the Caribbean"</p>
-        <p class="padding-sm">Tuesday, January 16, 2024, 5:00–6:30 pm EDT<br>"Confessions of a Telemanniac: Challenges and Opportunities for the Musician-Historian"</p>
-        <p class="padding-sm">Friday, February 23, 2024, 3:30–5:00 pm EDT<br>"Opera Seria, Identity, and the Performance of History"</p>
-        <p class="padding-sm">Friday, May 10, 2024, 1:30–3:00 pm EDT<br>"Non-Verbal Teaching of a Non-Verbal Art"</p>
         <p class="padding-md"><a href="https://encounters.secm.org" target="_blank"><i class="fas fa-external-link-square-alt" aria-hidden="true"></i> Learn more</a></p>
     </div>
 </div>
@@ -93,39 +88,19 @@
     <h2>Other Conferences and Events</h2>
     <div class="inner-container-col padding-top-xs">
         <p>
-            <strong>{{"Call for papers: International Scholarly Conference at the Handel Festival in Halle 2024"|upper}}</strong>
+            <strong>{{"Call for papers: International Scholarly Conference at the Handel Festival"|upper}}</strong>
         </p>
-        <p class="padding-sm">May 26–29, 2024 | Halle (Saale)</p>
-        <p>If one can trust the <em>Mémoires d'un Musicien</em> of 1756, then George Frideric Handel had in his library numerous volumes of operas by Jean-Baptiste Lully, André Campra, Jean-Marie Leclair, and Jean Philippe Rameau. These volumes included Rameau's works for keyboard and treatises on music. In 1733 Abbé Antoine François Prévost mentioned that Handel had "emprunté le fond d'une infinité de belles choses de Lully, et surtout des Cantates Françaises." This is a good reason to set up the International Conference to reconsider the conditions, requirements, scope, and significance of the impact of French music on Handel's oeuvre. These influences affect nearly all genres in his oeuvre: the Italian operas based on French librettos (<em>Teseo</em>, <em>Amadigi di Gaula</em>), and the English oratorios based on French plays (<em>Esther</em>, <em>Athalia</em>, <em>Theodora</em>, <em>Jephtha</em>), the overtures and suites for orchestra, and for harpsichord. The influences are also visible in the cantatas (of which the French <em>Sans y penser</em> is certainly a special case), in Handel's church music, the music for the stage drama <em>Alceste</em>, and in the collaboration with the French dancer Marie Sallé. The conference aims to explore the transfer routes of French music to Germany, Italy, and England as well as the adaptations and transformations of French models in Handel's works. Other focal points will be the history of the impact and performance of Handel's music and the changing images of Handel in France from the 18th century to the present. Comparative reflections on the reception of French music by Handel's contemporaries are also very welcome.</p>
-        <p>The organisers invite interested scholars to participate in the conference with a 25-minute paper and ask for an application with a proposal and abstract by <strong>October 15, 2023</strong>. Travel and accommodation costs will be covered for the conference days (three nights, May 26–29).</p>
+        <p class="padding-sm">June 10-11, 2025 | Halle (Saale)</p>
+        <p><strong>Handel’s Italian Texts and His Poets / Free Papers</strong></p>
+        <p>The Handel Festival 2025 in Halle an der Saale will take place under the motto "Fresh Wind. The young Handel in Italy." The International Scholarly Conference, held within the framework of the Festival, takes this as its cue to investigate the Italian texts set by Han (including those of his later career) and his contacts with Italian literature and poets. In a public round table chaired by Prof. em. Reinhard Strohm (Oxford), questions concerning the critical edition, translation and digitization of Handel’s Italian texts will be investigated and discussed.</p>
+        <p>We would welcome further contributions on these subjects, and on Handel’s trips to Italy as well as on the poets and translators with whom he collaborated, also beyond the Italian-language repertory. The conference should also include contributions on other eighteenth-century composers and their librettos and librettists. Finally, there will be scope for free papers, which would present new and recent results from Handel research to a public interested in scholarship.</p>
+        <p>The organisers invite researchers interested in these subjects to participate in the conference with a 25-minute paper and ask for applications with a subject proposal and an abstract by 31 October 2024. Travel and accommodation costs will be covered for the conference days (9/10, 10/11, 11/12 June).</p>
         <p><em>Organizers</em>: Georg-Friedrich-Händel-Gesellschaft e.V., Internationale Vereinigung; Martin-Luther Universität Halle-Wittenberg, Institut für Musik, Medien-und Sprechwissenschaften, Abteilung Musikwissenschaft; Stiftung Händel-Haus Halle.</p>
-        <p>Dr. Annette Landgraf, <a href="mailto:landgraf@musik.uni-halle.de">landgraf@musik.uni-halle.de</a><br>
-        Prof. Dr. Wolfgang Hirschmann, <a href="mailto:wolfgang.hirschmann@musik.uni-halle.de">mailto:wolfgang.hirschmann@musik.uni-halle.de</a><br>
-        Dr. Juliane Riepe, <a href="mailto:leitung.bibliothek@haendelhaus.de">leitung.bibliothek@haendelhaus.de</a><br>
-        Ulrike Harnisch, <a href="mailto:gesellschaft@haendel.de">gesellschaft@haendel.de</a></p>
-    </div>
-    <div class="inner-container-col padding-top-xs">
         <p>
-            <strong>{{"13th Handel Institute Conference, London"|upper}}</strong>
+            Dr. Annette Landgraf, <a href="mailto:landgraf@musik.uni-halle.de">landgraf@musik.uni-halle.de</a><br>
+            Prof. Dr. Wolfgang Hirschmann, <a href="mailto:wolfgang.hirschmann@musik.uni-halle.de">mailto:wolfgang.hirschmann@musik.uni-halle.de</a><br>
+            Ulrike Harnisch, <a href="mailto:gesellschaft@haendel.de">gesellschaft@haendel.de</a>
         </p>
-        <p class="padding-sm">November 17–19, 2023 | Bridewell Hall</p>
-        <p class="padding-md"><a href="https://handelinstitute.org/conference/2023" target="_blank"><i class="fas fa-external-link-square-alt" aria-hidden="true"></i> Learn more</a></p>
-    </div>
-    <div class="inner-container-col padding-top-xs">
-        <p>
-            <strong>{{"Halle Handel Festival"|upper}}</strong><br>
-            "Oh là là! Handel? - French inspirations"
-        </p>
-        <p class="padding-sm">May 24–June 9, 2024 | Halle (Saale)</p>
-        <p class="padding-md"><a href="https://haendelhaus.de/hfs/startseite" target="_blank"><i class="fas fa-external-link-square-alt" aria-hidden="true"></i> Learn more</a></p>
-    </div>
-    <div class="inner-container-col padding-top-xs">
-        <p>
-            <strong>{{"International Scholarly Conference, Halle (Saale)"|upper}}</strong><br>
-            "Endless Beauties: George Frideric Handel and French Music Culture"
-        </p>
-        <p class="padding-sm">May 27–29, 2024 | Halle (Saale)</p>
-        <p class="padding-md"><a href="https://www.haendel.de/scholarly-handel-conference/?lang=en" target="_blank"><i class="fas fa-external-link-square-alt" aria-hidden="true"></i> Learn more</a></p>
     </div>
 </div>
 


### PR DESCRIPTION
This PR revises the events page:
* removes old event data
* adds a CFP for the 2025 Halle festival