### PR TITLE
Include 'Boston 2025' in nav

### DIFF
--- a/americanhandelsociety_app/static/css/nav_bar.css
+++ b/americanhandelsociety_app/static/css/nav_bar.css
@@ -6,3 +6,7 @@
 .glow-nav-item > a {
     padding-left: 0;
 }
+
+.navbar-light .navbar-nav .nav-link {
+    color: #212529;
+}

--- a/americanhandelsociety_app/templates/partials/nav_bar.html
+++ b/americanhandelsociety_app/templates/partials/nav_bar.html
@@ -13,10 +13,21 @@
 		</button>
 	</div>
 	<div class="collapse navbar-collapse flex-grow-1 text-right" id="navbarSupportedContent">
-		<ul class="navbar-nav ms-auto flex-nowrap"></ul>
-			<li class="nav-item">
-				<a class="nav-link" href="{% url 'events' %}">Events</a>
+		<ul class="navbar-nav ms-auto flex-nowrap">
+			<li class="nav-item dropdown">
+				<a class="nav-link dropdown-toggle" href="#" id="navbarDropdownEvents" role="button"
+					data-bs-toggle="dropdown" aria-expanded="false">
+					Events
+				</a>
+				<ul class="dropdown-menu" aria-labelledby="navbarDropdownEvents">
+					<a class="dropdown-item" href="{% url 'conference' %}">Boston 2025</a>
+					<a class="dropdown-item" href="{% url 'events' %}">Events</a>
+
+				</ul>
 			</li>
+			<!-- <li class="nav-item">
+				<a class="nav-link" href="{% url 'events' %}">Events</a>
+			</li> -->
 			<li class="nav-item">
 				<a class="nav-link" href="{% url 'awards' %}">Awards</a>
 			</li>


### PR DESCRIPTION
This PR adds "Boston 2025" to the nav bar. It can remain there until the conference date passes.

Closes #209 