### PR TITLE
[Issue-218] Render the Zeffy form on Member Profile page

### DIFF
--- a/americanhandelsociety_app/constants.py
+++ b/americanhandelsociety_app/constants.py
@@ -1,3 +1,7 @@
+ZEFFY_EMBED_URL_FOR_RENEWAL_FORM = (
+    "https://www.zeffy.com/embed/ticketing/daa5a0a7-a8ff-4214-88eb-822fd0a78f8a"
+)
+
 RESEARCH_MATERIALS = {
     "open_source": [
         {

--- a/americanhandelsociety_app/constants.py
+++ b/americanhandelsociety_app/constants.py
@@ -1,5 +1,5 @@
 ZEFFY_EMBED_URL_FOR_RENEWAL_FORM = (
-    "https://www.zeffy.com/embed/ticketing/daa5a0a7-a8ff-4214-88eb-822fd0a78f8a"
+    "https://www.zeffy.com/embed/ticketing/membership-form-5"
 )
 
 RESEARCH_MATERIALS = {

--- a/americanhandelsociety_app/static/css/profile.css
+++ b/americanhandelsociety_app/static/css/profile.css
@@ -28,8 +28,15 @@
     padding: 1.2rem 1.2rem 1.2rem 0;
 }
 
-.renewal-msg {
+.renewal-msg, .beta-msg {
     font-size: 1.6rem;
+}
+
+.beta-msg {
+    margin: 20px 0px;
+}
+
+.renewal-msg {
     color: #b0b0b0;
     margin: 4px 0 20px 0;
 }

--- a/americanhandelsociety_app/templates/partials/nav_bar.html
+++ b/americanhandelsociety_app/templates/partials/nav_bar.html
@@ -55,7 +55,7 @@
 				<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
 					<li><a class="dropdown-item" href="{% url 'profile' %}">Profile</a></li>
 					{% if request.user|show_renew_nav_item %}
-					<li><a class="dropdown-item" href="{% url 'renew' %}">
+					<li><a class="dropdown-item" href="{% url 'profile' %}#membership">
 						<svg className={styles.letItGlowLarge} viewBox='0 0 1 1' height='30'>
 							<circle fill='#267abf' stroke='none' cx='.5' cy='.5' r='.2'>
 							<animate

--- a/americanhandelsociety_app/templates/profile.html
+++ b/americanhandelsociety_app/templates/profile.html
@@ -66,7 +66,7 @@
 			</div>
 		</div>
 	</div>
-	<div class="row">
+	<div id="membership" class="row">
 		<div class='col profile-card'>
 			<h2>Profile</h2>
 			<table class="profile-table">

--- a/americanhandelsociety_app/templates/profile.html
+++ b/americanhandelsociety_app/templates/profile.html
@@ -94,7 +94,7 @@
 						{% if payment_overdue %}
 							<p class="renewal-msg-error"><i class="fas fa-bell"></i> {{ renewal_msg }}</p>
 							<button zeffy-form-link="{% generate_renewal_url member %}" class="btn btn-primary">Renew membership</button>
-							<p class="beta-msg"><i class="fa-solid fa-circle-info"></i> Beta feature! The AHS uses Zeffy to process membership payments. Please report issues to <a href="mailto:reginafcompton@gmail.com">reginafcompton@gmail.com</a>.</p>
+							<p class="beta-msg"><i class="fa-solid fa-circle-info"></i> Beta feature! American Handel Society uses Zeffy to process membership payments. Report issues to <a href="mailto:reginafcompton@gmail.com">reginafcompton@gmail.com</a>.</p>
 						{% else %}
 							<div class="renewal-msg">{{ renewal_msg }}</div>
 						{% endif %}

--- a/americanhandelsociety_app/templates/profile.html
+++ b/americanhandelsociety_app/templates/profile.html
@@ -16,33 +16,33 @@
 			<div class="row mb-4">
 				<div class="col-md-6 mb-4">
 					<p class="text-muted">About You</p>
-					<p class="mb-0">{{ request.user.first_name }} {{ request.user.last_name }}</p>
-					<p class="mb-0">{{ request.user.email }}</p>
-					<p class="mb-0">{{ request.user.phone_number }}</p>
-					<p>{{ request.user.institution }}</p>
+					<p class="mb-0">{{ member.first_name }} {{ member.last_name }}</p>
+					<p class="mb-0">{{ member.email }}</p>
+					<p class="mb-0">{{ member.phone_number }}</p>
+					<p>{{ member.institution }}</p>
 				</div>
 				<div class="col-md-6">
-					{% if request.user.address %}
+					{% if member.address %}
 						<p class="text-muted">Mailing Address</p>
-						<p class="mb-0">{{ request.user.address.street_address }}</p>
-						<p class="mb-0">{{ request.user.address.street_address_2 }}</p>
-						<p class="mb-0">{{ request.user.address.street_address_3 }}</p>
-						<p class="mb-0">{{ request.user.address.city }} {{ request.user.address.state_province_region }} {{ request.user.address.zip_postal_code }}</p>
-						<p>{{ request.user.address.country }}</p>
+						<p class="mb-0">{{ member.address.street_address }}</p>
+						<p class="mb-0">{{ member.address.street_address_2 }}</p>
+						<p class="mb-0">{{ member.address.street_address_3 }}</p>
+						<p class="mb-0">{{ member.address.city }} {{ member.address.state_province_region }} {{ member.address.zip_postal_code }}</p>
+						<p>{{ member.address.country }}</p>
 					{% endif %}
 				</div>
-				{% if request.user.contact_preference %}
+				{% if member.contact_preference %}
 					<div class="col-xs-12 mt-2">
-						<p><i class="fa-solid fa-envelope-open-text"></i> You receive the AHS newsletter in <strong>{{request.user.contact_preference|format_contact_preference}}</strong> format.</p>
+						<p><i class="fa-solid fa-envelope-open-text"></i> You receive the AHS newsletter in <strong>{{member.contact_preference|format_contact_preference}}</strong> format.</p>
 					</div>
 				{% endif %}
-				{% if request.user.is_circle_member %}
+				{% if member.is_circle_member %}
 					<div class="col-xs-12 mt-2">
-						<p><i class="fa-solid fa-handshake"></i> {{request.user.publish_member_name_consent|format_publish_member_name_consent}}</p>
+						<p><i class="fa-solid fa-handshake"></i> {{member.publish_member_name_consent|format_publish_member_name_consent}}</p>
 					</div>
 				{% endif %}
 				<div class="col-xs-12 mt-2">
-					{% if request.user.available_in_directory %}
+					{% if member.available_in_directory %}
 						<p class="pb-4"><i class="fas fa-eye"></i> Members of the AHS can view your information in the online membership directory.</p>
 					{% else %}
 						<p class="pb-4"><i class="fas fa-eye-slash"></i> Members of the AHS cannot view your information in the online membership directory.</p>
@@ -76,16 +76,16 @@
 				</tr>
 				<tr>
 					<th>Membership Type</th>
-					<td>{{ request.user.membership_type|format_membership_type }}</td>
+					<td>{{ member.membership_type|format_membership_type }}</td>
 				</tr>
 				{% if not is_messiah_circle_member %}
 				<tr>
 					<th>Date Joined</th>
-					<td>{{ request.user.date_joined|date:'DATE_FORMAT' }}</td>
+					<td>{{ member.date_joined|date:'DATE_FORMAT' }}</td>
 				</tr>
 				<tr>
 					<th>Date of Last Membership Payment</th>
-					<td>{{ request.user.date_of_last_membership_payment|date:'DATE_FORMAT' }}</td>
+					<td>{{ member.date_of_last_membership_payment|date:'DATE_FORMAT' }}</td>
 				</tr>
 				<tr>
 					<th>Renewal Date</th>

--- a/americanhandelsociety_app/templates/profile.html
+++ b/americanhandelsociety_app/templates/profile.html
@@ -92,8 +92,9 @@
 					<td>
 						{{ renewal_date|date:'DATE_FORMAT' }}
 						{% if payment_overdue %}
-							<div class="renewal-msg-error"><i class="fas fa-bell"></i> {{ renewal_msg }}</div>
+							<p class="renewal-msg-error"><i class="fas fa-bell"></i> {{ renewal_msg }}</p>
 							<button zeffy-form-link="{% generate_renewal_url member %}" class="btn btn-primary">Renew membership</button>
+							<p class="beta-msg"><i class="fa-solid fa-circle-info"></i> Beta feature! The AHS uses Zeffy to process membership payments. Please report issues to <a href="mailto:reginafcompton@gmail.com">reginafcompton@gmail.com</a>.</p>
 						{% else %}
 							<div class="renewal-msg">{{ renewal_msg }}</div>
 						{% endif %}

--- a/americanhandelsociety_app/templates/profile.html
+++ b/americanhandelsociety_app/templates/profile.html
@@ -93,7 +93,7 @@
 						{{ renewal_date|date:'DATE_FORMAT' }}
 						{% if payment_overdue %}
 							<div class="renewal-msg-error"><i class="fas fa-bell"></i> {{ renewal_msg }}</div>
-							<a href="{% url 'renew' %}"><i class="fas fa-user"></i>&nbsp;Renew your membership</a>
+							<button zeffy-form-link="{% generate_renewal_url member %}" class="btn btn-primary">Renew membership</button>
 						{% else %}
 							<div class="renewal-msg">{{ renewal_msg }}</div>
 						{% endif %}
@@ -112,4 +112,9 @@
 	</div>
 </div>
 
+{% endblock %}
+
+{% block extra_js %}
+
+<script src="https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js"></script>
 {% endblock %}

--- a/americanhandelsociety_app/templatetags/profile_extras.py
+++ b/americanhandelsociety_app/templatetags/profile_extras.py
@@ -1,4 +1,7 @@
 from django import template
+from django.utils.http import urlencode
+
+from americanhandelsociety_app.constants import ZEFFY_EMBED_URL_FOR_RENEWAL_FORM
 
 register = template.Library()
 
@@ -19,3 +22,16 @@ def format_publish_member_name_consent(value):
         return "You did not grant permission to publish your name and membership tier."
     elif value == "ANONYMOUS":
         return 'You granted permission to publish your membership tier, but to display your name as "Anonymous."'
+
+
+@register.simple_tag
+def generate_renewal_url(member):
+    params = {
+        "modal": "true",
+        "email": member.email,
+        "firstName": member.first_name,
+        "lastName": member.last_name,
+    }
+    encoded_params = urlencode(params)
+
+    return f"{ZEFFY_EMBED_URL_FOR_RENEWAL_FORM}?{encoded_params}"

--- a/americanhandelsociety_app/views.py
+++ b/americanhandelsociety_app/views.py
@@ -62,6 +62,7 @@ class Profile(ProtectedView, View):
     template_name = "profile.html"
 
     def get(self, request, *args, **kwargs):
+        member = Member.objects.select_related("address").get(id=request.user.id)
         is_messiah_circle_member = (
             request.user.membership_type == Member.MembershipType.MESSIAH_CIRCLE
         )
@@ -87,6 +88,7 @@ class Profile(ProtectedView, View):
             self.template_name,
             context={
                 **kwargs,
+                "member": member,
                 "form_name": form_name,
                 "renewal_date": renewal_date,
                 "payment_overdue": payment_overdue,

--- a/tests/templatetags/test_profile_extras.py
+++ b/tests/templatetags/test_profile_extras.py
@@ -1,11 +1,12 @@
 import pytest
 
 from americanhandelsociety_app.templatetags.profile_extras import generate_renewal_url
+from americanhandelsociety_app.constants import ZEFFY_EMBED_URL_FOR_RENEWAL_FORM
 
 
 @pytest.mark.django_db
 def test_generate_renewal_url(member):
     assert (
         generate_renewal_url(member)
-        == "https://www.zeffy.com/embed/ticketing/daa5a0a7-a8ff-4214-88eb-822fd0a78f8a?modal=true&email=rodelinda%40lombardy.sa&firstName=Queen&lastName=Rodelinda"
+        == f"{ZEFFY_EMBED_URL_FOR_RENEWAL_FORM}?modal=true&email=rodelinda%40lombardy.sa&firstName=Queen&lastName=Rodelinda"
     )

--- a/tests/templatetags/test_profile_extras.py
+++ b/tests/templatetags/test_profile_extras.py
@@ -1,0 +1,11 @@
+import pytest
+
+from americanhandelsociety_app.templatetags.profile_extras import generate_renewal_url
+
+
+@pytest.mark.django_db
+def test_generate_renewal_url(member):
+    assert (
+        generate_renewal_url(member)
+        == "https://www.zeffy.com/embed/ticketing/daa5a0a7-a8ff-4214-88eb-822fd0a78f8a?modal=true&email=rodelinda%40lombardy.sa&firstName=Queen&lastName=Rodelinda"
+    )

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -51,7 +51,7 @@ def test_nav_join_other_orgs_link(client, member, subtests):
 
 @pytest.mark.django_db
 def test_nav_renew_link(client, member, subtests):
-    renew_link = '<a class="dropdown-item" href="/renew/">'
+    renew_link = '<a class="dropdown-item" href="/profile/#membership">'
 
     with subtests.test("user is not authenticated"):
         resp = client.get("/")


### PR DESCRIPTION
## Description
This PR renders the Zeffy form on a User's profile page.

## Manual testing

*I (Regina) completed the following steps. I do not expect the reviewer to do the same, since it entails accessing the AHS Zapier dashboard.*

N.b., these steps resemble those provided in https://github.com/americanhandelsociety/americanhandelsociety-members/pull/219

### Zapier setup
1. Setup an ngrok tunnel for your local Django app. (Don't forget to set the NGROK_DOMAIN environment variable.)
1. Visit the "Membership renewal" Zap: https://zapier.com/app/assets/zaps
1. Update the "POST in Webhooks by Zapier" with your ngrok domain.

### User Profile
- [ ] Create a User record. pipenv run python manage.py createsuperuser
- [ ] Edit your payment date to something in 2023 (i.e., ensure need to renew), and update your membership_type to something other than "REGULAR". Use the admin dashboard. https://4061-2601-702-0-1b40-de1-6e36-48c1-14f0.ngrok-free.app/admin/americanhandelsociety_app/member/
- [ ] Go to your profile page, and click "Renew membership" – BEHOLD THE EMBEDDED ZEFFY FORM!
- [ ] Select the $0 membership; submit.
- [ ] _You have to refresh the profile page to see changes reflected._ I am going to discuss with Minji how we want to handle this from a UX/UI perspective.

<img width="1254" alt="Screenshot 2024-12-06 at 1 31 04 PM" src="https://github.com/user-attachments/assets/1cd9fd97-5615-4a01-95c5-b260b98ce887">

<img width="1605" alt="Screenshot 2024-12-06 at 1 31 15 PM" src="https://github.com/user-attachments/assets/0d371b02-0d06-4eb8-8116-dd1efe11037c">






