### PR TITLE
[Issue-220] User DRF APIView and protect webhook with Token auth

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ django-simple-captcha = "*"
 django-waffle = "*"
 django-add-default-value = "*"
 time-machine = "*"
+djangorestframework = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "de071a49c4e7ecbb2033bc13d19b130090fecc9c2366e2700256a78bb01b59c0"
+            "sha256": "ec3b3f8708a4ca7abaa3bd244fcbe25168ed863caca3127c74e288b0eed3aff5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -199,6 +199,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==4.2.0"
+        },
+        "djangorestframework": {
+            "hashes": [
+                "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20",
+                "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.15.2"
         },
         "fontawesomefree": {
             "hashes": [
@@ -425,11 +434,11 @@
         },
         "sqlparse": {
             "hashes": [
-                "sha256:9e37b35e16d1cc652a2545f0997c1deb23ea28fa1f3eefe609eee3063c3b105f",
-                "sha256:e99bc85c78160918c3e1d9230834ab8d80fc06c59d03f8db2618f65f65dda55e"
+                "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272",
+                "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.5.2"
+            "version": "==0.5.3"
         },
         "time-machine": {
             "hashes": [

--- a/americanhandelsociety/settings.py
+++ b/americanhandelsociety/settings.py
@@ -40,6 +40,8 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "rest_framework",
+    "rest_framework.authtoken",
     "fontawesomefree",
     "paypal.standard.ipn",
     "captcha",

--- a/americanhandelsociety_app/webhooks.py
+++ b/americanhandelsociety_app/webhooks.py
@@ -5,6 +5,8 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 from rest_framework import status, serializers
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAdminUser
 
 from americanhandelsociety_app.models import Member
 
@@ -40,6 +42,8 @@ class MemberRenewalSerializer(serializers.ModelSerializer):
 
 
 class MembershipRenewalWebhook(GenericAPIView):
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAdminUser]
     serializer_class = MemberRenewalSerializer
 
     def handle_error(self, error: dict, status_code: int = status.HTTP_400_BAD_REQUEST):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
-import json
 import logging
 import os
 from time import sleep
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from string import ascii_lowercase
+from random import sample
 
 import docker
 import pytest
-from string import ascii_lowercase
-from random import sample
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
+from rest_framework.authtoken.models import Token
 
 from americanhandelsociety_app.models import Member, Address
 
@@ -205,6 +205,17 @@ def circle_member(address):
 
 
 @pytest.fixture
+def auth_headers():
+    superuser = Member.objects.create_superuser(
+        email="admin@superuser.com",
+        password="supersecret",
+    )
+    token, _ = Token.objects.get_or_create(user=superuser)
+
+    return {"HTTP_AUTHORIZATION": f"Token {token.key}"}
+
+
+@pytest.fixture
 def member_not_in_directory():
     data = {
         "email": "gismonda@rome.sa",
@@ -306,4 +317,3 @@ def members_of_all_types():
             filter(lambda x: not_dunder(x), dir(Member.MembershipType))
         )
     ]
-    return members_list

--- a/tests/webhooks/test_membership_renewal.py
+++ b/tests/webhooks/test_membership_renewal.py
@@ -3,74 +3,85 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from time_machine import travel
+from rest_framework.authtoken.models import Token
 
 from americanhandelsociety_app.models import Member
 
 
-# Re-add test when doing
-# def test_returns_403_if_user_is_not_authenticated(client):
-#     resp = client.post(f"/membership-renewal-webhook/", data={})
-#     assert resp.status_code == 403
+def test_returns_401_if_user_is_not_authenticated(client):
+    resp = client.post(f"/membership-renewal-webhook/", data={})
+    assert resp.status_code == 401
 
 
 @pytest.mark.django_db
-def test_returns_400_if_payload_omits_email(client, member):
+def test_returns_401_if_user_is_not_an_admin(client, member):
+    token, _ = Token.objects.get_or_create(user=member)
+    resp = client.post(
+        f"/membership-renewal-webhook/",
+        data={},
+        headers={"HTTP_AUTHORIZATION": f"Token {token.key}"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.django_db
+def test_returns_400_if_payload_omits_email(client, member, auth_headers):
     data = {
         "membership_type": "AHS Regular",
         "first_name": member.first_name,
         "last_name": member.last_name,
     }
 
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
+    resp = client.post(f"/membership-renewal-webhook/", data=data, **auth_headers)
 
     assert resp.status_code == 400
     assert resp.json() == {"email": ["This field is required."]}
 
 
 @pytest.mark.django_db
-def test_returns_400_if_payload_omits_membership_type(client, member):
+def test_returns_400_if_payload_omits_membership_type(client, member, auth_headers):
     data = {
         "email": member.email,
         "first_name": member.first_name,
         "last_name": member.last_name,
     }
 
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
+    resp = client.post(f"/membership-renewal-webhook/", data=data, **auth_headers)
 
     assert resp.status_code == 400
     assert resp.json() == {"membership_type": ["This field is required."]}
 
 
 @pytest.mark.django_db
-def test_returns_400_if_payload_omits_first_name(client, member):
+def test_returns_400_if_payload_omits_first_name(client, member, auth_headers):
     data = {
         "email": member.email,
         "membership_type": "Regular",
         "last_name": member.last_name,
     }
 
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
+    resp = client.post(f"/membership-renewal-webhook/", data=data, **auth_headers)
 
     assert resp.status_code == 400
     assert resp.json() == {"first_name": ["This field is required."]}
 
 
 @pytest.mark.django_db
-def test_returns_400_if_payload_omits_last_name(client, member):
+def test_returns_400_if_payload_omits_last_name(client, member, auth_headers):
     data = {
         "email": member.email,
         "membership_type": "Regular",
         "first_name": member.first_name,
     }
 
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
+    resp = client.post(f"/membership-renewal-webhook/", data=data, **auth_headers)
 
     assert resp.status_code == 400
     assert resp.json() == {"last_name": ["This field is required."]}
 
 
 @pytest.mark.django_db
-def test_returns_400_if_membership_type_is_not_valid(client, member):
+def test_returns_400_if_membership_type_is_not_valid(client, member, auth_headers):
     bad_type = "INVALID"
     data = {
         "email": member.email,
@@ -79,14 +90,16 @@ def test_returns_400_if_membership_type_is_not_valid(client, member):
         "last_name": member.last_name,
     }
 
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
+    resp = client.post(f"/membership-renewal-webhook/", data=data, **auth_headers)
 
     assert resp.status_code == 400
     assert resp.json() == {"membership_type": [f'"{bad_type}" is not a valid choice.']}
 
 
 @pytest.mark.django_db
-def test_returns_400_if_email_does_not_match_existing_record(client, member):
+def test_returns_400_if_email_does_not_match_existing_record(
+    client, member, auth_headers
+):
     bad_email = "user@test.com"
     data = {
         "email": bad_email,
@@ -95,7 +108,7 @@ def test_returns_400_if_email_does_not_match_existing_record(client, member):
         "last_name": member.last_name,
     }
 
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
+    resp = client.post(f"/membership-renewal-webhook/", data=data, **auth_headers)
 
     assert resp.status_code == 400
     assert resp.json() == {
@@ -107,7 +120,7 @@ def test_returns_400_if_email_does_not_match_existing_record(client, member):
 
 @travel(datetime(2024, 1, 1, 0, 0, tzinfo=ZoneInfo("America/New_York")))
 @pytest.mark.django_db
-def test_success(client, member, subtests):
+def test_success(client, member, auth_headers, subtests):
     data = {
         "email": member.email,
         "membership_type": "Cleopatra Circle",
@@ -115,7 +128,7 @@ def test_success(client, member, subtests):
         "last_name": member.last_name,
     }
 
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
+    resp = client.post(f"/membership-renewal-webhook/", data=data, **auth_headers)
 
     with subtests.test("returns 'ok' response"):
         assert resp.status_code == 200
@@ -140,7 +153,7 @@ def test_success(client, member, subtests):
 
 
 @pytest.mark.django_db
-def test_uses_ahs_confirmed_email_for_lookup(client, member):
+def test_uses_ahs_confirmed_email_for_lookup(client, member, auth_headers):
     data = {
         "email": "something.for.payment@test.com",
         "membership_type": "Cleopatra Circle",
@@ -149,7 +162,7 @@ def test_uses_ahs_confirmed_email_for_lookup(client, member):
         "confirmed_member_email": member.email,
     }
 
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
+    resp = client.post(f"/membership-renewal-webhook/", data=data, **auth_headers)
 
     assert resp.status_code == 200
     assert resp.json()["member_email"] == member.email

--- a/tests/webhooks/test_membership_renewal.py
+++ b/tests/webhooks/test_membership_renewal.py
@@ -16,7 +16,7 @@ from americanhandelsociety_app.models import Member
 @pytest.mark.django_db
 def test_returns_400_if_payload_omits_email(client, member):
     data = {
-        "membership_type": "Regular",
+        "membership_type": "AHS Regular",
         "first_name": member.first_name,
         "last_name": member.last_name,
     }
@@ -24,7 +24,7 @@ def test_returns_400_if_payload_omits_email(client, member):
     resp = client.post(f"/membership-renewal-webhook/", data=data)
 
     assert resp.status_code == 400
-    assert resp.json() == {"email": "Required field."}
+    assert resp.json() == {"email": ["This field is required."]}
 
 
 @pytest.mark.django_db
@@ -38,7 +38,7 @@ def test_returns_400_if_payload_omits_membership_type(client, member):
     resp = client.post(f"/membership-renewal-webhook/", data=data)
 
     assert resp.status_code == 400
-    assert resp.json() == {"membership_type": "Required field."}
+    assert resp.json() == {"membership_type": ["This field is required."]}
 
 
 @pytest.mark.django_db
@@ -52,7 +52,7 @@ def test_returns_400_if_payload_omits_first_name(client, member):
     resp = client.post(f"/membership-renewal-webhook/", data=data)
 
     assert resp.status_code == 400
-    assert resp.json() == {"first_name": "Required field."}
+    assert resp.json() == {"first_name": ["This field is required."]}
 
 
 @pytest.mark.django_db
@@ -66,28 +66,7 @@ def test_returns_400_if_payload_omits_last_name(client, member):
     resp = client.post(f"/membership-renewal-webhook/", data=data)
 
     assert resp.status_code == 400
-    assert resp.json() == {"last_name": "Required field."}
-
-
-@pytest.mark.django_db
-def test_returns_400_if_email_does_not_match_existing_record(client, member):
-    bad_email = "user@test.com"
-    data = {
-        "email": bad_email,
-        "membership_type": "Regular",
-        "first_name": member.first_name,
-        "last_name": member.last_name,
-    }
-
-    resp = client.post(f"/membership-renewal-webhook/", data=data)
-
-    assert resp.status_code == 400
-
-    assert resp.json() == {
-        "error": {
-            "message": f"ObjectDoesNotExist: Cannot find a Member with email '{bad_email}'"
-        }
-    }
+    assert resp.json() == {"last_name": ["This field is required."]}
 
 
 @pytest.mark.django_db
@@ -103,8 +82,26 @@ def test_returns_400_if_membership_type_is_not_valid(client, member):
     resp = client.post(f"/membership-renewal-webhook/", data=data)
 
     assert resp.status_code == 400
+    assert resp.json() == {"membership_type": [f'"{bad_type}" is not a valid choice.']}
+
+
+@pytest.mark.django_db
+def test_returns_400_if_email_does_not_match_existing_record(client, member):
+    bad_email = "user@test.com"
+    data = {
+        "email": bad_email,
+        "membership_type": "Regular",
+        "first_name": member.first_name,
+        "last_name": member.last_name,
+    }
+
+    resp = client.post(f"/membership-renewal-webhook/", data=data)
+
+    assert resp.status_code == 400
     assert resp.json() == {
-        "error": {"message": [f"Value '{bad_type}' is not a valid choice."]}
+        "error": {
+            "message": f"ObjectDoesNotExist: Cannot find a Member with email '{bad_email}'"
+        }
     }
 
 


### PR DESCRIPTION
## Description 

This PR introduces django-rest-framework. Doing so makes possible the following:

1. Rewriting the `MembershipRenewalWebhook` as a standard `GenericAPIView` (e.g., with a serializer).
2. Protecting the API with permissions and auth checks.

Closes #220 

## Manual testing

- [ ] Follow setup steps here: https://github.com/americanhandelsociety/americanhandelsociety-members/pull/221
- [ ] Create a Token for your superuser (via Django admin):
<img width="1766" alt="Screenshot 2024-12-13 at 4 27 46 PM" src="https://github.com/user-attachments/assets/ecb01417-9611-43fa-bebc-62b55be28ae7" />

- [ ] Configure the "Zap" to use the Token in the POST headers:

<img width="443" alt="Screenshot 2024-12-13 at 4 28 45 PM" src="https://github.com/user-attachments/assets/e6c516c6-1005-45b5-9e8b-c1c914cb64cc" />





