### PR TITLE
Remove events dropdown

### DIFF
--- a/americanhandelsociety_app/templates/partials/nav_bar.html
+++ b/americanhandelsociety_app/templates/partials/nav_bar.html
@@ -14,7 +14,7 @@
 	</div>
 	<div class="collapse navbar-collapse flex-grow-1 text-right" id="navbarSupportedContent">
 		<ul class="navbar-nav ms-auto flex-nowrap">
-			<li class="nav-item dropdown">
+			<!-- <li class="nav-item dropdown">
 				<a class="nav-link dropdown-toggle" href="#" id="navbarDropdownEvents" role="button"
 					data-bs-toggle="dropdown" aria-expanded="false">
 					Events
@@ -24,10 +24,10 @@
 					<a class="dropdown-item" href="{% url 'events' %}">Events</a>
 
 				</ul>
-			</li>
-			<!-- <li class="nav-item">
-				<a class="nav-link" href="{% url 'events' %}">Events</a>
 			</li> -->
+			<li class="nav-item">
+				<a class="nav-link" href="{% url 'events' %}">Events</a>
+			</li>
 			<li class="nav-item">
 				<a class="nav-link" href="{% url 'awards' %}">Awards</a>
 			</li>


### PR DESCRIPTION
This PR removes the "Events" dropdown; we're no longer clearly exposing the 2025 conference page.